### PR TITLE
Fix duplicated word in two HTML pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                 </li>
                 <li>
                     <h3><a href="online-veiligheid.html">Online veiligheid</a></h3>
-                    <p>Superintelligente AI maakt ons kwetsbaar voor sabotage, misinformatie, spionage en digitale aanvallen. We moeten fors investeren in AI-veiligheid en cyberweerbaarheid en op dat gebied samen werken met partners in de EU. ASML maakt ons onmisbaar is in de wereldwijde AI-keten—maar ook kwetsbaar.</p>
+                    <p>Superintelligente AI maakt ons kwetsbaar voor sabotage, misinformatie, spionage en digitale aanvallen. We moeten fors investeren in AI-veiligheid en cyberweerbaarheid en op dat gebied samen werken met partners in de EU. ASML maakt ons onmisbaar in de wereldwijde AI-keten—maar ook kwetsbaar.</p>
                 </li>
             </ol>
         </section>

--- a/online-veiligheid.html
+++ b/online-veiligheid.html
@@ -14,7 +14,7 @@
         </header>
         
         <section class="recommendation-content">
-            <p>Superintelligente AI maakt ons kwetsbaar voor sabotage, misinformatie, spionage en digitale aanvallen. We moeten fors investeren in AI-veiligheid en cyberweerbaarheid en op dat gebied samen werken met partners in de EU. ASML maakt ons onmisbaar is in de wereldwijde AI-keten—maar ook kwetsbaar.</p>
+            <p>Superintelligente AI maakt ons kwetsbaar voor sabotage, misinformatie, spionage en digitale aanvallen. We moeten fors investeren in AI-veiligheid en cyberweerbaarheid en op dat gebied samen werken met partners in de EU. ASML maakt ons onmisbaar in de wereldwijde AI-keten—maar ook kwetsbaar.</p>
         </section>
         
         <footer>


### PR DESCRIPTION
## Summary
- remove extra `is` from the online safety text on the index page
- apply the same fix to the `online-veiligheid.html` page

## Testing
- `npm run build`